### PR TITLE
adds GitHub workflow to publish npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish NPM Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Insert Git hash into package.json as gitHash
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          cat <<< "$(jq --arg gh "$GIT_HASH" '.gitHash = $gh' < package.json)" > package.json
+
+      - name: Install dependencies
+        run: yarn --non-interactive --frozen-lockfile
+
+      - name: Publish
+        run: npm publish --access public
+        working-directory: ./
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
adapts existing workflows from ironfish-cli, ironfish-wallet-cli

uses organization NPM_TOKEN secret to publish '@ironfish/multisig-broker' package to npm registry

Closes IFL-3092