### PR TITLE
rejects client messages if client not in session

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,7 @@ export const MultisigBrokerErrorCodes = {
   INVALID_DKG_SESSION_ID: 3,
   INVALID_SIGNING_SESSION_ID: 4,
   IDENTITY_NOT_ALLOWED: 5,
+  NON_SESSION_CLIENT: 6,
 }
 
 export class MessageMalformedError extends Error {


### PR DESCRIPTION
## Summary

updates the multisig broker server to reject data submissions from clients that haven't joined the session

does not return session status if client not in session

sends an error message for 'NON_SESSION_CLIENT'

consolidates session validation logic to reduce repeated code

Closes IFL-3087

## Testing plan
1. Apply the diff below to prevent the server from adding the client who starts the session to the session:
```
diff --git a/src/server.ts b/src/server.ts
index d5fdb00..17d9180 100644
--- a/src/server.ts
+++ b/src/server.ts
@@ -480,7 +480,7 @@ export class MultisigServer {
     this.logger.debug(`Client ${client.id} started dkg session ${message.sessionId}`)
 
     client.identity = body.result.identity
-    this.addClientToSession(client, sessionId)
+    // this.addClientToSession(client, sessionId)
 
     this.send(client.socket, 'joined_session', message.sessionId, {
       challenge: session.challenge,
```
2. run `yarn build`
3. start a dev server using `yarn start`
4. start a dkg session using `ironfish wallet:multisig:dkg:start --server --no-tls --hostname localhost -v`
5. observe error messages as the client tries to retrieve status without joining the session