### PR TITLE
rejects clients joining full dkg sessions

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,6 +11,7 @@ export const MultisigBrokerErrorCodes = {
   INVALID_SIGNING_SESSION_ID: 4,
   IDENTITY_NOT_ALLOWED: 5,
   NON_SESSION_CLIENT: 6,
+  DKG_SESSION_FULL: 7,
 }
 
 export class MessageMalformedError extends Error {

--- a/src/server.ts
+++ b/src/server.ts
@@ -567,6 +567,16 @@ export class MultisigServer {
       return
     }
 
+    if (isDkgSession(session) && session.clientIds.size >= session.status.maxSigners) {
+      this.sendErrorMessage(
+        client,
+        message.id,
+        'DKG session is full',
+        MultisigBrokerErrorCodes.DKG_SESSION_FULL,
+      )
+      return
+    }
+
     this.logger.debug(`Client ${client.id} joined session ${message.sessionId}`)
 
     this.addClientToSession(client, message.sessionId)

--- a/src/server.ts
+++ b/src/server.ts
@@ -567,7 +567,7 @@ export class MultisigServer {
       return
     }
 
-    if (isDkgSession(session) && session.clientIds.size >= session.status.maxSigners) {
+    if (isDkgSession(session) && session.clientIds.size === session.status.maxSigners) {
       this.sendErrorMessage(
         client,
         message.id,


### PR DESCRIPTION
## Summary

if the maximum number of participants (according to the session config) have already joined a DKG session then the server prevents new clients from joining the session and returns an error message

Closes IFL-3097

## Testing plan

1. Run `yarn build`
2. Run `yarn start` to start dev server
3. Start dkg session with 2 participants using `ironfish wallet:multisig:dkg:create --hostname localhost --ledger`. Use a ledger so that round1 doesn't automatically start after joining with the second client
4. Join the session with a second client
5. Try to join the session with a third client. The client will wait indefinitely and display an error when running in verbose mode