### PR TITLE
removes unused error types

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -55,20 +55,4 @@ export class MultisigClientError extends Error {
   name = this.constructor.name
 }
 
-export class SessionDecryptionError extends MultisigClientError {
-  constructor(message: string) {
-    super(message)
-  }
-}
-
-export class InvalidSessionError extends MultisigClientError {
-  constructor(message: string) {
-    super(message)
-  }
-}
-
-export class IdentityNotAllowedError extends MultisigClientError {
-  constructor(message: string) {
-    super(message)
-  }
-}
+export class SessionDecryptionError extends MultisigClientError {}


### PR DESCRIPTION
removes InvalidSessionError and IdentityNotAllowedError. these errors are not thrown by this package, so they should not be defined here.

removes unneeded implementation of constructor for SessionDecryptionError